### PR TITLE
Adds shebang to launch_listener.sh

### DIFF
--- a/scripts/spotify/launchlistener.sh
+++ b/scripts/spotify/launchlistener.sh
@@ -1,1 +1,3 @@
+#!/usr/bin/env sh
+
 /usr/bin/env python3 ~/scripts/spotify/py_spotify_listener.py


### PR DESCRIPTION
Adds shebang to launch_listener.sh so this bash file works on systems that have other shells other than bash as default