### PR TITLE
Move IPC logic to polybar-msg

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,8 @@ The spotify hook-1 (2) will run another python script which returns the current 
 ### Set up
 - Install all dependencies
 - Copy all scripts to `~/scripts`
-- Have polybar start up on boot and [create a symlink as documented](https://github.com/jaagr/polybar/wiki/Inter-process-messaging) to `/tmp/ipc-bottom`
-- Have the `scripts/spotify/launchlistener.sh` script start up on boot
-- Make sure the bar you want to add it to has [IPC enabled](https://github.com/jaagr/polybar/wiki/Module:-ipc)
+- Have polybar start up on boot- Have the `scripts/spotify/launchlistener.sh` script start up on boot
+- Make sure the bars you want to add it to has [IPC enabled](https://github.com/jaagr/polybar/wiki/Module:-ipc)
 
 ### Adding all modules
 Add all of the desired modules to any bar and modify to your likings. This is my setup:

--- a/scripts/spotify/py_spotify_listener.py
+++ b/scripts/spotify/py_spotify_listener.py
@@ -4,6 +4,7 @@
 """Receiver related functionality."""
 import dbus.service
 import dbus.glib
+from os import system
 from gi.repository import GObject
 import dbus
 
@@ -58,17 +59,14 @@ def event_handler(*args, **kwargs):
     data = unwrap(args)
     if data[1]['PlaybackStatus'] == "Playing":
         print("Music is playing")
-        """ Send IPC hook 2 to the bottom bar pid for module playpause """
-        with open("/tmp/ipc-bottom", "w") as text_file:
-            print("hook:module/playpause2", file=text_file)
+        system("polybar-msg hook playpause 2")
+        """ Send IPC hook 2 to all bars for module playpause """
     if data[1]['PlaybackStatus'] == "Paused":
         print("Music is paused.")
-        """ Send IPC hook 3 to the bottom bar pid for module playpause """
-        with open("/tmp/ipc-bottom", "w") as text_file:
-            print("hook:module/playpause3", file=text_file)
-    """ Send IPC hook 2 to the bottom bar pid for module spotify """
-    with open("/tmp/ipc-bottom", "w") as text_file:
-        print("hook:module/spotify2", file=text_file)
+        """ Send IPC hook 3 to all bars module playpause """
+        system("polybar-msg hook playpause 3")
+    """ Send IPC hook 2 to all bars for module spotify """
+    system("polybar-msg hook spotify 2")
 
 def unwrap(val):
     if isinstance(val, dbus.ByteArray):


### PR DESCRIPTION
Quick fix to move the messaging from the /tmp/bottombar fifo into the new polybar-msg.
Makes installation easier, and should fix the multimonitor issues.