### PR TITLE
Added exact match option to pgrep

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ format-padding = 5
 ; Previous song icon
 exec = echo ""
 ; Check if spotify is running before displaying the icon
-exec-if = "pgrep spotify"
+exec-if = "pgrep spotify -x"
 format-underline = #1db954
 line-size = 1
 click-left = "dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.Previous"
@@ -76,7 +76,7 @@ format-padding = 5
 ; Next song icon
 exec = echo ""
 ; Check if spotify is running before displaying the icon
-exec-if = "pgrep spotify"
+exec-if = "pgrep spotify -x"
 format-underline = #1db954
 line-size = 1
 click-left = "dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.Next"


### PR DESCRIPTION
There was a bug where the previous and next options appeared even when spotify wasnt open. It was because the pgrep didnt look for the exact match.